### PR TITLE
Fix handling of invalid input in UnitSelectControl

### DIFF
--- a/components/input/index.tsx
+++ b/components/input/index.tsx
@@ -26,6 +26,12 @@ const ForwardedInputControl = forwardRef<HTMLInputElement, InputControlProps>(
 		const inputSuffix = (
 			<UnitSelectControl
 				onChange={(newUnit) => {
+					// If the number is invalid, set it to 16px or 1rem
+					if (isNaN(Number(num)) || num === '') {
+						onChange(`${newUnit === 'px' ? '16' : '1'}${newUnit}`);
+						return;
+					}
+
 					if (unit === 'px' && newUnit === 'rem') {
 						onChange(`${parseFloat(num) / 16}${newUnit}`);
 					} else if (unit === 'rem' && newUnit === 'px') {


### PR DESCRIPTION
Thankyou for developing such a handy tool.

This PR fixes a small bug that occurs when trying to change the unit type when the input is empty

![Screenshot 2023-09-06 154240](https://github.com/walbo/font-size-clamp/assets/67187467/298f65eb-fb27-4fe5-8932-5f2685c09c52)

which also gave the following console warning: 

```bash
The specified value "NaN" cannot be parsed, or is out of range.
```

Input now falls back to `1rem` or `16px` when trying to change the unittype.